### PR TITLE
Add missing simplejson requirement

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,1 +1,2 @@
+simplejson
 requests==2.2.1


### PR DESCRIPTION
Oops... simplejson is not part of the base python install!
